### PR TITLE
Implement SQLAlchemy storage for balances and transactions

### DIFF
--- a/python/db.py
+++ b/python/db.py
@@ -1,0 +1,79 @@
+import os
+from datetime import datetime, date
+from decimal import Decimal
+from sqlalchemy import (create_engine, Column, String, Integer, Numeric, Date,
+                        DateTime, ForeignKey, JSON, UniqueConstraint, Index, func)
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+
+DB_URL = os.getenv("DATABASE_URL", "sqlite:///devin_teller.db")
+engine = create_engine(DB_URL, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+Base = declarative_base()
+
+class Account(Base):
+    __tablename__ = "accounts"
+    id = Column(String, primary_key=True)           # Teller account id
+    name = Column(String)
+    institution_id = Column(String)
+    type = Column(String)
+    subtype = Column(String)
+    last_four = Column(String)
+    created_at = Column(DateTime, server_default=func.now())
+    updated_at = Column(DateTime, onupdate=func.now())
+
+class BalanceSnapshot(Base):
+    __tablename__ = "balance_snapshots"
+    id = Column(Integer, primary_key=True)
+    account_id = Column(String, ForeignKey("accounts.id"), index=True)
+    available = Column(Numeric(14, 2))
+    ledger = Column(Numeric(14, 2))
+    as_of = Column(DateTime, default=func.now(), index=True)
+    raw = Column(JSON)
+    account = relationship("Account")
+    __table_args__ = (UniqueConstraint("account_id", "as_of", name="uq_bal_asof"),)
+
+class Transaction(Base):
+    __tablename__ = "transactions"
+    id = Column(String, primary_key=True)           # Teller txn id
+    account_id = Column(String, ForeignKey("accounts.id"), index=True)
+    date = Column(Date, index=True)
+    description = Column(String)
+    amount = Column(Numeric(14, 2))
+    raw = Column(JSON)
+    account = relationship("Account")
+    __table_args__ = (Index("ix_txn_acct_date", "account_id", "date"),)
+
+def init_db():
+    Base.metadata.create_all(engine)
+
+def upsert_account(s, acct_json):
+    obj = s.get(Account, acct_json["id"]) or Account(id=acct_json["id"])
+    obj.name = acct_json.get("name")
+    obj.institution_id = acct_json.get("institution", {}).get("id")
+    obj.type = acct_json.get("type")
+    obj.subtype = acct_json.get("subtype")
+    obj.last_four = acct_json.get("last_four")
+    s.add(obj)
+    return obj
+
+def add_balance_snapshot(s, account_id, balances_json):
+    snap = BalanceSnapshot(
+        account_id=account_id,
+        available=Decimal(str(balances_json.get("available", 0))),
+        ledger=Decimal(str(balances_json.get("ledger", 0))),
+        raw=balances_json,
+    )
+    s.add(snap)
+
+def upsert_transactions(s, account_id, txns_json):
+    for t in txns_json:
+        if s.get(Transaction, t["id"]):
+            continue
+        s.add(Transaction(
+            id=t["id"],
+            account_id=account_id,
+            date=date.fromisoformat(t["date"]),
+            description=t.get("description"),
+            amount=Decimal(str(t.get("amount", 0))),
+            raw=t,
+        ))

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,3 +4,5 @@ falcon==3.0.1
 idna==2.10
 requests==2.25.1
 urllib3==1.26.6
+SQLAlchemy>=2
+psycopg2-binary

--- a/python/teller.py
+++ b/python/teller.py
@@ -61,10 +61,34 @@ class AccountsResource:
         self._proxy(req, resp, lambda client: client.get_account_details(account_id))
 
     def on_get_balances(self, req, resp, account_id):
-        self._proxy(req, resp, lambda client: client.get_account_balances(account_id))
+        def store_balances(client):
+            teller_response = client.get_account_balances(account_id)
+            if teller_response.status_code == 200:
+                try:
+                    from db import SessionLocal, init_db, add_balance_snapshot
+                    init_db()
+                    with SessionLocal() as s:
+                        add_balance_snapshot(s, account_id, teller_response.json())
+                        s.commit()
+                except Exception as e:
+                    print(f"Error storing balance snapshot: {e}")
+            return teller_response
+        self._proxy(req, resp, store_balances)
 
     def on_get_transactions(self, req, resp, account_id):
-        self._proxy(req, resp, lambda client: client.list_account_transactions(account_id))
+        def store_transactions(client):
+            teller_response = client.list_account_transactions(account_id)
+            if teller_response.status_code == 200:
+                try:
+                    from db import SessionLocal, init_db, upsert_transactions
+                    init_db()
+                    with SessionLocal() as s:
+                        upsert_transactions(s, account_id, teller_response.json())
+                        s.commit()
+                except Exception as e:
+                    print(f"Error storing transactions: {e}")
+            return teller_response
+        self._proxy(req, resp, store_transactions)
 
     def on_get_payees(self, req, resp, account_id, scheme):
         self._proxy(req, resp, lambda client: client.list_account_payees(account_id, scheme))
@@ -74,6 +98,34 @@ class AccountsResource:
 
     def on_post_payments(self, req, resp, account_id, scheme):
         self._proxy(req, resp, lambda client: client.create_account_payment(account_id, scheme, req.media))
+
+    def on_get_cached_transactions(self, req, resp, account_id):
+        try:
+            from db import SessionLocal, Transaction
+            limit = int(req.get_param('limit', default=100))
+            with SessionLocal() as s:
+                rows = (s.query(Transaction)
+                          .filter_by(account_id=account_id)
+                          .order_by(Transaction.date.desc())
+                          .limit(limit)
+                          .all())
+                resp.media = [r.raw for r in rows]
+        except Exception as e:
+            print(f"Error retrieving cached transactions: {e}")
+            resp.media = []
+
+    def on_get_cached_balances(self, req, resp, account_id):
+        try:
+            from db import SessionLocal, BalanceSnapshot
+            with SessionLocal() as s:
+                latest = (s.query(BalanceSnapshot)
+                           .filter_by(account_id=account_id)
+                           .order_by(BalanceSnapshot.as_of.desc())
+                           .first())
+                resp.media = latest.raw if latest else {}
+        except Exception as e:
+            print(f"Error retrieving cached balances: {e}")
+            resp.media = {}
 
     def _proxy(self, req, resp, fun):
         user_client = self._client.for_user(req.auth)
@@ -163,6 +215,10 @@ def main():
             suffix='payees')
     app.add_route('/api/accounts/{account_id}/payments/{scheme}', accounts,
             suffix='payments')
+    app.add_route('/api/db/accounts/{account_id}/transactions', accounts,
+            suffix='cached_transactions')
+    app.add_route('/api/db/accounts/{account_id}/balances', accounts,
+            suffix='cached_balances')
 
     port = os.getenv('PORT') or '8001'
 


### PR DESCRIPTION
# Implement SQLAlchemy storage for balances and transactions

## Summary

Adds persistent storage for balance and transaction data using SQLAlchemy. When users fetch balances or transactions through the existing API endpoints, the data is now automatically stored in a database for caching and historical tracking.

**Key changes:**
- Added SQLAlchemy 2.0+ and PostgreSQL support via new dependencies
- Created database models for Account, BalanceSnapshot, and Transaction with proper indexing
- Integrated storage as a side effect of successful Teller API calls in `on_get_balances` and `on_get_transactions`
- Added new cached read endpoints: `/api/db/accounts/{id}/transactions` and `/api/db/accounts/{id}/balances`
- Maintains full backward compatibility - existing API responses are unchanged
- Supports both SQLite (default) and PostgreSQL via `DATABASE_URL` environment variable

## Review & Testing Checklist for Human

**🔴 Critical (4 items) - This PR adds significant database complexity that requires thorough testing:**

- [ ] **End-to-end storage testing**: Connect a real sandbox account and verify that clicking "Balances" and "Transactions" buttons actually stores data in the database, then test the cached endpoints return the stored data
- [ ] **Database schema validation**: Verify `devin_teller.db` is created properly and contains the expected tables with correct structure after running the application
- [ ] **Error scenario testing**: Test behavior when database is unavailable/corrupted, when Teller API returns unexpected JSON formats, and when storage operations fail
- [ ] **Data integrity verification**: Ensure that duplicate transactions are handled correctly and that balance snapshots don't create constraint violations under concurrent access

### Test Commands
```bash
# Start with database storage
export DATABASE_URL=sqlite:///devin_teller.db
python python/teller.py --environment sandbox

# Test cached endpoints after connecting an account
curl -i http://localhost:8001/api/db/accounts/{account_id}/transactions?limit=10
curl -i http://localhost:8001/api/db/accounts/{account_id}/balances
```

### Notes
- Storage operations are wrapped in try/catch blocks to prevent database issues from breaking existing API functionality
- The implementation calls `init_db()` on every request for simplicity, but this should be optimized for production use
- Decimal type is used for financial amounts to ensure precision
- **Testing limitation**: Due to sandbox login credential issues, the storage flow was only partially tested - cached endpoints work but return empty results since no data was stored yet


**Requested by:** David Van Osdol (@dvanosdol88)  
**Devin session:** https://app.devin.ai/sessions/ca559aafbb8e414d8166337d202dea47